### PR TITLE
chore: demo patch bump (5.8.3 → 5.8.4)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -424,4 +424,4 @@ variable "putin_khuylo" {
   type        = bool
   default     = true
 }
-# Demo trigger: patch bump at 2026-03-09T00:58:09Z
+# Demo trigger: patch bump at 2026-03-09T01:06:47Z


### PR DESCRIPTION
Automated demo trigger for consumer module uplift pipeline.

Bumps module version via `patch` release: `5.8.3` → `5.8.4`

_Created by `publish-module-version.sh` — safe to merge._