### PR TITLE
feat: change test_new_module type from bool to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ No modules.
 | <a name="input_server_side_encryption_configuration"></a> [server\_side\_encryption\_configuration](#input\_server\_side\_encryption\_configuration) | Map containing server-side encryption configuration. | `any` | `{}` | no |
 | <a name="input_skip_destroy_public_access_block"></a> [skip\_destroy\_public\_access\_block](#input\_skip\_destroy\_public\_access\_block) | Whether to skip destroying the S3 Bucket Public Access Block configuration when destroying the bucket. Only used if `public_access_block` is set to true. | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+| <a name="input_test_new_module"></a> [test\_new\_module](#input\_test\_new\_module) | Whether to test new module | `string` | `""` | no |
 | <a name="input_transition_default_minimum_object_size"></a> [transition\_default\_minimum\_object\_size](#input\_transition\_default\_minimum\_object\_size) | The default minimum object size behavior applied to the lifecycle configuration. Valid values: all\_storage\_classes\_128K (default), varies\_by\_storage\_class | `string` | `null` | no |
 | <a name="input_type"></a> [type](#input\_type) | Bucket type. Valid values: `Directory` | `string` | `"Directory"` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | Map containing versioning configuration. | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -427,7 +427,7 @@ variable "putin_khuylo" {
 
 variable "test_new_module" {
   description = "Whether to test new module"
-  type        = bool
-  default     = false
+  type        = string
+  default     = ""
 }
 


### PR DESCRIPTION
## Summary
- Changed `test_new_module` variable type from `bool` to `string`
- Updated default value from `false` to `""` (empty string)

## Test plan
- [ ] Verify `terraform validate` passes
- [ ] Confirm no existing references to `var.test_new_module` are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)