### PR TITLE
chore: demo minor bump (5.8.6 → 5.9.0)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -430,4 +430,4 @@ variable "test_new_module" {
   type        = string
   default     = ""
 }
-# Demo trigger: patch bump at 2026-03-09T09:15:16Z
+# Demo trigger: minor bump at 2026-03-09T09:44:29Z


### PR DESCRIPTION
Automated demo trigger for consumer module uplift pipeline.

Bumps module version via `minor` release: `5.8.6` → `5.9.0`

_Created by `publish-module-version.sh` — safe to merge._