### PR TITLE
chore: demo major bump (5.9.0 → 6.0.0)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -430,4 +430,4 @@ variable "test_new_module" {
   type        = string
   default     = ""
 }
-# Demo trigger: minor bump at 2026-03-09T09:44:29Z
+# Demo trigger: major bump at 2026-03-09T22:55:16Z


### PR DESCRIPTION
Automated demo trigger for consumer module uplift pipeline.

Bumps module version via `major` release: `5.9.0` → `6.0.0`

_Created by `publish-module-version.sh` — safe to merge._