### PR TITLE
chore: demo patch bump (6.0.0 → 6.0.1)

### DIFF
--- a/.cache/trivy/policy/metadata.json
+++ b/.cache/trivy/policy/metadata.json
@@ -1,1 +1,1 @@
-{"Digest":"sha256:ff1f8aeb19a802446ed4125bd084f2d6f50ad6800328fee24a4bc2f5a03c23c1","DownloadedAt":"2026-03-09T00:15:58.119071746Z","MajorVersion":2}
+{"Digest":"sha256:ff1f8aeb19a802446ed4125bd084f2d6f50ad6800328fee24a4bc2f5a03c23c1","DownloadedAt":"2026-03-10T01:06:28.33546784Z","MajorVersion":2}

--- a/variables.tf
+++ b/variables.tf
@@ -430,4 +430,4 @@ variable "test_new_module" {
   type        = string
   default     = ""
 }
-# Demo trigger: major bump at 2026-03-09T22:55:16Z
+# Demo trigger: patch bump at 2026-03-10T01:05:58Z


### PR DESCRIPTION
Automated demo trigger for consumer module uplift pipeline.

Bumps module version via `patch` release: `6.0.0` → `6.0.1`

_Created by `publish-module-version.sh` — safe to merge._